### PR TITLE
Omit unnecessary files from the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "main": "dist/commonjs/main.js",
   "module": "dist/es-module/main.js",
   "umd:main": "dist/main.js",
+  "files": [
+    "dist",
+    "full.js",
+    "full.d.ts"
+  ],
   "keywords": [
     "week",
     "start",


### PR DESCRIPTION
This will improve two things:

* This will make the published npm module smaller
* Remove `doc` folder from the published artifacts, which was concerning some security scanners